### PR TITLE
Add section about unified development environment to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When the instrumented program is executed, it will generate a compressed log fil
 
 From this description it is clear that the trace viewer and this workbench will share common functions for how to interact with the design. So I will be specifying those functions as a [library][dal-engine-core-js] that is maintained separately and imported into both these applications. 
 
-## Unified Development Environment
+## Unified Development Environment (UDE)
 
 The current configuration consists of separate tools: the design workbench, instrumentation layer, trace viewer, and automated testing framework. For now, each component is being developed independently in order to establish and validate the core functionality of the system.
 


### PR DESCRIPTION
This PR adds a section about the unified development environment to the readme. It highlights the upcoming changes that will unify all components of the system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated library references in the main description to point to the new engine package.
  * Added a "Unified Development Environment" section outlining architecture, minimal initial configuration, frontend/server integration, workspace/IDE roles, trace persistence and viewing, invariant-driven evolution, and automated testing.
  * Reorganized documentation and added external reference links for the new engine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->