### PR TITLE
docs: Add information about workbench modes to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This means that the workbench will contain a few unique modes:
 - Design Definition
 - Implementation
 - Mapping
-- Instrumention and Execution
+- Instrumentation and Execution
 - Automated Debugging
 - Learning
 - Automated Testing
@@ -28,7 +28,7 @@ All of these modes are intrinsic to the design feedback loop shown below and the
 
 ![alt text](docs/design_feedback_loop.jpg)
 
-By leveraging design driven automation, the design workbench establishes the structure need to practically enable the automatic management of software systems. Ultimately, this marks the shift away from the inherent uncertainty of traditional observability platforms and marks the arrival of deterministic understanding and complete automation enabled by the Design Learning Platform (DLP).
+By leveraging design-driven automation, the design workbench establishes the structure needed to practically enable the automatic management of software systems. Ultimately, this marks the shift away from the inherent uncertainty of traditional observability platforms and marks the arrival of deterministic understanding and complete automation enabled by the Design Learning Platform (DLP).
 
 ## Development
 


### PR DESCRIPTION
This PR adds changes to the readme that I didn't push before merging. The information it adds is about the different modes the workbench can be in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and expanded the design feedback loop section with descriptions of key workbench modes
  * Enhanced explanations of workbench participation in the complete development cycle
  * Updated documentation to clarify the platform's shift toward deterministic understanding and comprehensive automation capabilities for software system management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->