### PR TITLE
Fix terminal behavior when entry point script finishes. (fixes #27)

### DIFF
--- a/server/src/websocketHandlers.js
+++ b/server/src/websocketHandlers.js
@@ -162,30 +162,33 @@ export class  WSMessageHandler {
         this.terminal.write(msg.data);
     }
 
-    onTerminalRunEntryPoint = async (msg) => {        
-        let entryPointFinishedSent = false;
-        
-        const handleFinished = async () => {
-            if (!entryPointFinishedSent) {
-                entryPointFinishedSent = true;
-                const traceEntry = await saveTraceInEngine();
-                if (traceEntry) {
-                    this.sendMessage({ type: "add_trace", data: traceEntry });
-                } else {
-                    console.warn("No trace entry to send to front end.");
-                }
-                
-                this.startTerminalAndAddListeners();
+    handleEntryPointFinished = async () => {
+        if (this.entryPointFinishedSent) return;
+
+        this.entryPointFinishedSent = true;
+        try {
+            const traceEntry = await saveTraceInEngine();
+            if (traceEntry) {
+                this.sendMessage({ type: "add_trace", data: traceEntry });
+            } else {
+                console.warn("No trace entry to send to front end.");
             }
+        } catch (err) {
+            console.error("Failed to save trace:", err);
         }
+        this.startTerminalAndAddListeners();
+    }
+
+    onTerminalRunEntryPoint = async (msg) => {        
+        this.entryPointFinishedSent = false;
 
         await clearTraceFilesInPlayground();
         this.stopTerminalAndRemoveListeners();
         this.terminal = new TerminalSession({ command: msg.data });
         this.terminal.on("data", this.onTerminalData);
-        this.terminal.on("exit", handleFinished);
+        this.terminal.on("exit", this.handleEntryPointFinished);
         this.terminal.on("start", this.onTerminalStart);
-        this.terminal.on("stop", handleFinished);
+        this.terminal.on("stop", this.handleEntryPointFinished);
         this.terminal.start();
     }
 }

--- a/server/src/websocketHandlers.js
+++ b/server/src/websocketHandlers.js
@@ -28,7 +28,6 @@ export class  WSMessageHandler {
             delete_design: this.deleteDesign.bind(this),
             load_design: this.loadDesign.bind(this),
             terminal_run_entry_point: this.onTerminalRunEntryPoint.bind(this),
-            entry_point_finished: this.onEntryPointFinished.bind(this),
         };
     }
 
@@ -163,29 +162,30 @@ export class  WSMessageHandler {
         this.terminal.write(msg.data);
     }
 
-    onEntryPointFinished = async (msg) => { 
-        const traceEntry = await saveTraceInEngine();
-        if (traceEntry) {
-            this.sendMessage({ type: "add_trace", data: traceEntry });
-        } else {
-            console.warn("No trace entry to send to front end.");
-        }
-        this.startTerminalAndAddListeners();
-    }   
-
     onTerminalRunEntryPoint = async (msg) => {        
-        // Since both stop and exit run, we use a flag ensure only
-        // one entry_point_finished message is sent.
         let entryPointFinishedSent = false;
-        const handleFinished = () => {
+        
+        const handleFinished = async () => {
             if (!entryPointFinishedSent) {
                 entryPointFinishedSent = true;
-                this.sendMessage({ type: "entry_point_finished" });
+                const traceEntry = await saveTraceInEngine();
+                if (traceEntry) {
+                    this.sendMessage({ type: "add_trace", data: traceEntry });
+                } else {
+                    console.warn("No trace entry to send to front end.");
+                }
+                
+                this.startTerminalAndAddListeners();
             }
         }
 
         await clearTraceFilesInPlayground();
         this.stopTerminalAndRemoveListeners();
-        this.startTerminalAndAddListeners({ command: msg.data });
+        this.terminal = new TerminalSession({ command: msg.data });
+        this.terminal.on("data", this.onTerminalData);
+        this.terminal.on("exit", handleFinished);
+        this.terminal.on("start", this.onTerminalStart);
+        this.terminal.on("stop", handleFinished);
+        this.terminal.start();
     }
 }

--- a/workbench/src/Providers/GlobalProviders.js
+++ b/workbench/src/Providers/GlobalProviders.js
@@ -80,9 +80,6 @@ function GlobalProviders ({children}) {
             case "design_save_failed":
                 dispatch(setStatusMsg("Failed to save design."));
                 break;
-            case "entry_point_finished":
-                sendMessage({type: "entry_point_finished"});
-                break;
             case "add_trace":
                 dispatch(addTraceThunk(msg.data));
                 dispatch(setStatusMsg("Received trace from server."));


### PR DESCRIPTION
As issue #27 describes, when the entry point script finishes, the terminal stops prompting the user. 

When the instrumented program is run by executing the entry point script, it is run on a separate terminal instance that terminates when the program is done (either by close or error). This lets me react to the application being done to save the trace in the engine. 

However, this means that when the terminal errs or closes, I need to save the trace and then start a new terminal for the prompt to continue in the front end. While doing some refactoring, I introduced a bug and stopped reacting to the terminal closing or erring. 

This PR fixes that issue.

In my previous implementation, I was sending a redundant message to the front end to and asking it to prompt me to save the trace. This PR also fixes that by directly handles the trace management after the entry point script finishes.

## Validation Performed

- Ran the entry point script
- Terminated the program manually
- Verified that prompt was restored
- Ran the entry point script
- Terminated the program through an error
- Verified that the program was restored
- In both cases, verified that the generated trace was available in the trace view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated entry-point completion into terminal/session lifecycle for cleaner session management.
* **Bug Fix**
  * Ensures trace saving and notification occur only once and adds error handling to avoid silent failures.
* **Chore**
  * Removed obsolete message handling pathway from the message processing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->