### PR TITLE
Set the initial select value of prediction modal to the UID instead of behavior name. 

### DIFF
--- a/workbench/src/Components/Modals/AddPrediction.js
+++ b/workbench/src/Components/Modals/AddPrediction.js
@@ -26,7 +26,7 @@ export function AddPrediction ({close}) {
 
     useEffect(() => {
         if (behaviors && Object.values(behaviors).length > 0) {
-            setPrediction(Object.values(behaviors)[0]._name|| "");
+            setPrediction(Object.values(behaviors)[0].dal_engine_uid);
         }
     }, [behaviors]);
 


### PR DESCRIPTION
See issue #31 for details.

## Validation Performed

Verified that I was able to assign a predict behavior using the default select value.